### PR TITLE
Don't attempt to parse system messages as commands.

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -177,7 +177,10 @@ test = 0
 async def on_message(message):
 	global serverVoices, serverAdmins, soundsDir, serverPunish, nsohandler, owners
 
+	# Filter out bots and system messages
 	if message.author.bot:
+		return
+	elif message.type != discord.MessageType.default:
 		return
 
 	command = message.content.lower()


### PR DESCRIPTION
I suspect this will fix the occasional "string index out of range" exceptions.